### PR TITLE
refactor: set script perms during copy

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 ARG ALPINE_VERSION=3.22
 ARG ALPINE_BRANCH=3.22-stable
 
@@ -77,7 +78,6 @@ COPY --from=apkbuild /home/builder/out/*.rsa.pub /etc/apk/keys/
 COPY --from=apkbuild /home/builder/out/openvpn-*.apk /tmp/
 RUN apk add --no-cache /tmp/openvpn-*.apk && rm -f /tmp/openvpn-*.apk
 
-COPY openvpn.sh /openvpn.sh
-RUN chmod +x /openvpn.sh
+COPY --chmod=0755 openvpn.sh /openvpn.sh
 WORKDIR /vpn
 ENTRYPOINT ["/sbin/tini","--","/openvpn.sh"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -79,8 +79,7 @@ RUN groupadd -r vpn \
 COPY --from=build /src/openvpn_*_*.deb /tmp/
 RUN apt-get update && apt-get install -y /tmp/openvpn_*_*.deb && rm -rf /var/lib/apt/lists/*
 
-COPY openvpn.sh /openvpn.sh
-RUN chmod +x /openvpn.sh
+COPY --chmod=0755 openvpn.sh /openvpn.sh
 WORKDIR /vpn
 ENTRYPOINT ["/usr/bin/tini","--","/openvpn.sh"]
 


### PR DESCRIPTION
## Summary
- use BuildKit's `COPY --chmod` to set executable bit for `openvpn.sh`
- add Dockerfile syntax directive to Alpine build

## Testing
- `docker build -f Dockerfile.alpine -t test-alpine .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*


------
https://chatgpt.com/codex/tasks/task_e_68a12861d350833280060e2c50251f21