### PR TITLE
fix: define base digest in build-alpine workflow

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -98,6 +98,7 @@ jobs:
           echo "latest=${{ steps.tags.outputs.latest }}"     >> "$GITHUB_OUTPUT"
 
           IMAGE="${{ steps.tags.outputs.primary }}"
+          BASE_DIGEST="${{ steps.alpine-version.outputs.base_digest }}"
 
           if docker pull "$IMAGE" >/dev/null 2>&1; then
             REMOTE_BASE=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.base.digest" }}' "$IMAGE" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- define `BASE_DIGEST` in build-alpine workflow to avoid unbound variable errors during scheduled runs

## Testing
- `actionlint .github/workflows/build-alpine.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a1d4bf1d148332b7701849d0fb8d1e