### PR TITLE
Fix remote base digest detection and label generation in Debian and Alpine workflows

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -33,7 +33,8 @@ jobs:
     outputs:
       alpine_version: ${{ steps.out.outputs.alpine_version }}
       alpine_branch:  ${{ steps.out.outputs.alpine_branch }}
-      base_digest: ${{ steps.out.outputs.base_digest }}
+      base_digest_amd64: ${{ steps.out.outputs.base_digest_amd64 }}
+      base_digest_arm64: ${{ steps.out.outputs.base_digest_arm64 }}
       apk_version: ${{ steps.out.outputs.apk_version }}
       primary: ${{ steps.out.outputs.primary }}
       compat1: ${{ steps.out.outputs.compat1 }}
@@ -49,10 +50,13 @@ jobs:
             grep VERSION_ID | \
             awk -F'=' ' { print $NF } ' | \
             tr -d '[:space:]')
-          BASE_DIGEST=$(docker manifest inspect "alpine:${ALPINE_VERSION}" | awk -F\" '/"digest":/ {print $4; exit}')
-          echo "Alpine stable version: $ALPINE_VERSION (BASE_DIGEST=$BASE_DIGEST)"
+          BASE_JSON=$(docker manifest inspect "alpine:${ALPINE_VERSION}")
+          BASE_DIGEST_AMD64=$(printf '%s' "$BASE_JSON" | python -c 'import json,sys; m=json.load(sys.stdin); print([d["digest"] for d in m["manifests"] if d["platform"]["architecture"]=="amd64"][0])')
+          BASE_DIGEST_ARM64=$(printf '%s' "$BASE_JSON" | python -c 'import json,sys; m=json.load(sys.stdin); print([d["digest"] for d in m["manifests"] if d["platform"]["architecture"]=="arm64"][0])')
+          echo "Alpine stable version: $ALPINE_VERSION (BASE_DIGEST_AMD64=$BASE_DIGEST_AMD64; BASE_DIGEST_ARM64=$BASE_DIGEST_ARM64)"
           echo "alpine_version=$ALPINE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "base_digest=$BASE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "base_digest_amd64=$BASE_DIGEST_AMD64" >> "$GITHUB_OUTPUT"
+          echo "base_digest_arm64=$BASE_DIGEST_ARM64" >> "$GITHUB_OUTPUT"
 
       - name: Compute Alpine branch (major.minor-stable)
         id: alpine-branch
@@ -91,16 +95,22 @@ jobs:
           echo "alpine_version=${{ steps.alpine-version.outputs.alpine_version }}" >> "$GITHUB_OUTPUT"
           echo "alpine_branch=${{ steps.alpine-branch.outputs.alpine_branch }}"    >> "$GITHUB_OUTPUT"
           echo "apk_version=${{ steps.openvpn-version.outputs.apk_version }}" >> "$GITHUB_OUTPUT"
-          echo "base_digest=${{ steps.alpine-version.outputs.base_digest }}" >> "$GITHUB_OUTPUT"
           echo "primary=${{ steps.tags.outputs.primary }}"   >> "$GITHUB_OUTPUT"
           echo "compat1=${{ steps.tags.outputs.compat1 }}"   >> "$GITHUB_OUTPUT"
           echo "compat2=${{ steps.tags.outputs.compat2 }}"   >> "$GITHUB_OUTPUT"
           echo "latest=${{ steps.tags.outputs.latest }}"     >> "$GITHUB_OUTPUT"
+          echo "base_digest_amd64=${{ steps.alpine-version.outputs.base_digest_amd64 }}" >> "$GITHUB_OUTPUT"
+          echo "base_digest_arm64=${{ steps.alpine-version.outputs.base_digest_arm64 }}" >> "$GITHUB_OUTPUT"
 
           IMAGE="${{ steps.tags.outputs.primary }}"
+          BASE_DIGEST="${{ steps.alpine-version.outputs.base_digest_amd64 }}"
 
           if docker pull "$IMAGE" >/dev/null 2>&1; then
-            REMOTE_BASE=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.base.digest" }}' "$IMAGE" 2>/dev/null || true)
+            DIGEST=$(docker image inspect "$IMAGE" --format '{{ index .RepoDigests 0 }}' 2>/dev/null || true)
+            REMOTE_BASE=""
+            if [ -n "$DIGEST" ]; then
+              REMOTE_BASE=$(docker image inspect "$DIGEST" --format '{{ index .Config.Labels "org.opencontainers.image.base.digest" }}' 2>/dev/null || true)
+            fi
             echo "Image already exists, digest: $REMOTE_BASE"
           else
             echo "Image does not exist"
@@ -136,6 +146,7 @@ jobs:
           build-args: |
             ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
             ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
+            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-amd64
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-amd64
@@ -143,7 +154,6 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
             org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
-            org.opencontainers.image.base.digest=${{ needs.prepare.outputs.base_digest }}
             org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -171,6 +181,7 @@ jobs:
           build-args: |
             ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
             ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
+            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-arm64
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-arm64
@@ -178,7 +189,6 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
             org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
-            org.opencontainers.image.base.digest=${{ needs.prepare.outputs.base_digest }}
             org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       codename: ${{ steps.out.outputs.codename }}
-      base_digest: ${{ steps.out.outputs.base_digest }}
+      base_digest_amd64: ${{ steps.out.outputs.base_digest_amd64 }}
+      base_digest_arm64: ${{ steps.out.outputs.base_digest_arm64 }}
       deb_version: ${{ steps.out.outputs.deb_version }}
       safe_deb_version: ${{ steps.out.outputs.safe_deb_version }}
       primary: ${{ steps.out.outputs.primary }}
@@ -49,11 +50,14 @@ jobs:
           OSREL=$(docker run --rm debian:stable-slim bash -lc 'cat /etc/os-release')
           CODENAME=$(printf "%s" "$OSREL" | awk -F= '/^VERSION_CODENAME=/{print $2}')
           VERSION_ID=$(printf "%s" "$OSREL" | awk -F= '/^VERSION_ID=/{print $2}')
-          BASE_DIGEST=$(docker manifest inspect "debian:${CODENAME}-slim" | awk -F\" '/"digest":/ {print $4; exit}')
-          echo "Debian stable codename: $CODENAME (VERSION_ID=$VERSION_ID; BASE_DIGEST=$BASE_DIGEST)"
+          BASE_JSON=$(docker manifest inspect "debian:${CODENAME}-slim")
+          BASE_DIGEST_AMD64=$(printf '%s' "$BASE_JSON" | python -c 'import json,sys; m=json.load(sys.stdin); print([d["digest"] for d in m["manifests"] if d["platform"]["architecture"]=="amd64"][0])')
+          BASE_DIGEST_ARM64=$(printf '%s' "$BASE_JSON" | python -c 'import json,sys; m=json.load(sys.stdin); print([d["digest"] for d in m["manifests"] if d["platform"]["architecture"]=="arm64"][0])')
+          echo "Debian stable codename: $CODENAME (VERSION_ID=$VERSION_ID; BASE_DIGEST_AMD64=$BASE_DIGEST_AMD64; BASE_DIGEST_ARM64=$BASE_DIGEST_ARM64)"
           echo "codename=$CODENAME" >> "$GITHUB_OUTPUT"
           echo "version_id=$VERSION_ID" >> "$GITHUB_OUTPUT"
-          echo "base_digest=$BASE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "base_digest_amd64=$BASE_DIGEST_AMD64" >> "$GITHUB_OUTPUT"
+          echo "base_digest_arm64=$BASE_DIGEST_ARM64" >> "$GITHUB_OUTPUT"
 
       - name: Extract openvpn version
         id: openvpn-version
@@ -91,11 +95,18 @@ jobs:
           echo "compat1=${{ steps.tags.outputs.compat1 }}"   >> "$GITHUB_OUTPUT"
           echo "compat2=${{ steps.tags.outputs.compat2 }}"   >> "$GITHUB_OUTPUT"
           echo "latest=${{ steps.tags.outputs.latest }}"     >> "$GITHUB_OUTPUT"
+          echo "base_digest_amd64=${{ steps.debian-version.outputs.base_digest_amd64 }}" >> "$GITHUB_OUTPUT"
+          echo "base_digest_arm64=${{ steps.debian-version.outputs.base_digest_arm64 }}" >> "$GITHUB_OUTPUT"
 
           IMAGE="${{ steps.tags.outputs.primary }}"
+          BASE_DIGEST="${{ steps.debian-version.outputs.base_digest_amd64 }}"
 
           if docker pull "$IMAGE" >/dev/null 2>&1; then
-            REMOTE_BASE=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.base.digest" }}' "$IMAGE" 2>/dev/null || true)
+            DIGEST=$(docker image inspect "$IMAGE" --format '{{ index .RepoDigests 0 }}' 2>/dev/null || true)
+            REMOTE_BASE=""
+            if [ -n "$DIGEST" ]; then
+              REMOTE_BASE=$(docker image inspect "$DIGEST" --format '{{ index .Config.Labels "org.opencontainers.image.base.digest" }}' 2>/dev/null || true)
+            fi
             echo "Image already exists, digest: $REMOTE_BASE"
           else
             echo "Image does not exist"
@@ -131,6 +142,7 @@ jobs:
           build-args: |
             BASE_SUITE=${{ needs.prepare.outputs.codename }}
             OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
+            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-amd64
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-amd64
@@ -138,7 +150,6 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
             org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
-            org.opencontainers.image.base.digest=${{ needs.prepare.outputs.base_digest }}
             org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -166,6 +177,7 @@ jobs:
           build-args: |
             BASE_SUITE=${{ needs.prepare.outputs.codename }}
             OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
+            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-arm64
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-arm64
@@ -173,7 +185,6 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
             org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
-            org.opencontainers.image.base.digest=${{ needs.prepare.outputs.base_digest }}
             org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG ALPINE_VERSION=3.22
 ARG ALPINE_BRANCH=3.22-stable
+ARG BASE_DIGEST
 
 # ---------- build custom .apk from aports (non-root) ----------
 ARG ALPINE_VERSION
@@ -61,8 +62,10 @@ RUN set -eux; \
 
 # ---------- minimal runtime (unchanged) ----------
 ARG ALPINE_VERSION
+ARG BASE_DIGEST
 FROM alpine:${ALPINE_VERSION}
-LABEL maintainer="Guillaume Filion <guillaume@filion.org>"
+LABEL maintainer="Guillaume Filion <guillaume@filion.org>" \
+      org.opencontainers.image.base.digest=$BASE_DIGEST
 
 RUN apk --no-cache --no-progress upgrade && \
     apk --no-cache --no-progress add \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,6 +3,7 @@
 # Use a dedicated arg for FROM, to avoid scope collisions
 ARG BASE_SUITE=trixie
 ARG OPENVPN_VERSION=2.6.14-1
+ARG BASE_DIGEST
 
 # ---------- build (Debian packaging on ${BASE_SUITE}) ----------
 ARG BASE_SUITE
@@ -58,8 +59,10 @@ RUN set -eux; \
 
 # ---------- runtime (${BASE_SUITE}, dperson UX) ----------
 ARG BASE_SUITE
+ARG BASE_DIGEST
 FROM debian:${BASE_SUITE}-slim
-LABEL maintainer="Guillaume Filion <guillaume@filion.org>"
+LABEL maintainer="Guillaume Filion <guillaume@filion.org>" \
+      org.opencontainers.image.base.digest=$BASE_DIGEST
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- detect platform-specific base image digests for Debian and Alpine builds
- propagate the computed digests into Dockerfiles to label images with `org.opencontainers.image.base.digest`

## Testing
- `python -m yamllint .github/workflows/build-debian.yml` *(fails: line-length errors)*
- `python -m yamllint .github/workflows/build-alpine.yml` *(fails: line-length and spacing errors)*
- `./hadolint Dockerfile.debian` *(warnings about pinning versions and other style issues)*
- `./hadolint Dockerfile.alpine` *(error: use of sudo; warnings about version pinning and quoting)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d6770d348332ab5640a6ddc84b17