### PR TITLE
Add longpass version test

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -136,27 +136,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push (amd64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.alpine
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
-            ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
-            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-amd64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-amd64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-amd64
-          labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
-            org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
-            org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        - name: Build & push (amd64)
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: ./Dockerfile.alpine
+            platforms: linux/amd64
+            push: true
+            build-args: |
+              ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
+              ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
+              BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
+            tags: |
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-amd64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-amd64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-amd64
+            labels: |
+              org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
+              org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
+              org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+
+        - name: Test OpenVPN version (amd64)
+          run: |
+            set -euo pipefail
+            docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-amd64 openvpn --version | head -n1 | grep -q 'longpass1'
 
   build-arm64:
     needs: prepare
@@ -171,27 +176,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push (arm64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.alpine
-          platforms: linux/arm64
-          push: true
-          build-args: |
-            ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
-            ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
-            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-arm64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-arm64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-arm64
-          labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
-            org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
-            org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        - name: Build & push (arm64)
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: ./Dockerfile.alpine
+            platforms: linux/arm64
+            push: true
+            build-args: |
+              ALPINE_VERSION=${{ needs.prepare.outputs.alpine_version }}
+              ALPINE_BRANCH=${{ needs.prepare.outputs.alpine_branch }}
+              BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
+            tags: |
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-arm64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-alpine-${{ needs.prepare.outputs.alpine_version }}-arm64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.apk_version }}-arm64
+            labels: |
+              org.opencontainers.image.version=${{ needs.prepare.outputs.apk_version }}
+              org.opencontainers.image.base.name=alpine:${{ needs.prepare.outputs.alpine_version }}
+              org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.apk_version }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+
+        - name: Test OpenVPN version (arm64)
+          run: |
+            set -euo pipefail
+            docker run --rm --platform linux/arm64 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:alpine-${{ needs.prepare.outputs.alpine_version }}-openvpn-${{ needs.prepare.outputs.apk_version }}-arm64 openvpn --version | head -n1 | grep -q 'longpass1'
 
   # Optional: keep a slow QEMU build for arm/v7 (Raspberry Pi OS 32-bit)
   # build-armv7:

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -132,27 +132,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push (amd64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile.debian
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            BASE_SUITE=${{ needs.prepare.outputs.codename }}
-            OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
-            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-amd64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-amd64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-amd64
-          labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
-            org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
-            org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        - name: Build & push (amd64)
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: Dockerfile.debian
+            platforms: linux/amd64
+            push: true
+            build-args: |
+              BASE_SUITE=${{ needs.prepare.outputs.codename }}
+              OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
+              BASE_DIGEST=${{ needs.prepare.outputs.base_digest_amd64 }}
+            tags: |
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-amd64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-amd64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-amd64
+            labels: |
+              org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
+              org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
+              org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+
+        - name: Test OpenVPN version (amd64)
+          run: |
+            set -euo pipefail
+            docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-amd64 openvpn --version | head -n1 | grep -q 'longpass1'
 
   build-arm64:
     needs: prepare
@@ -167,27 +172,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push (arm64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile.debian
-          platforms: linux/arm64
-          push: true
-          build-args: |
-            BASE_SUITE=${{ needs.prepare.outputs.codename }}
-            OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
-            BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-arm64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-arm64
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-arm64
-          labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
-            org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
-            org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        - name: Build & push (arm64)
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: Dockerfile.debian
+            platforms: linux/arm64
+            push: true
+            build-args: |
+              BASE_SUITE=${{ needs.prepare.outputs.codename }}
+              OPENVPN_VERSION=${{ needs.prepare.outputs.deb_version }}
+              BASE_DIGEST=${{ needs.prepare.outputs.base_digest_arm64 }}
+            tags: |
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-arm64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-debian-${{ needs.prepare.outputs.codename }}-arm64
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.safe_deb_version }}-arm64
+            labels: |
+              org.opencontainers.image.version=${{ needs.prepare.outputs.deb_version }}
+              org.opencontainers.image.base.name=debian:${{ needs.prepare.outputs.codename }}-slim
+              org.opencontainers.image.ref.name=openvpn=${{ needs.prepare.outputs.deb_version }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+
+        - name: Test OpenVPN version (arm64)
+          run: |
+            set -euo pipefail
+            docker run --rm --platform linux/arm64 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian-${{ needs.prepare.outputs.codename }}-openvpn-${{ needs.prepare.outputs.safe_deb_version }}-arm64 openvpn --version | head -n1 | grep -q 'longpass1'
 
   # Optional: keep a slow QEMU build for arm/v7 (Raspberry Pi OS 32-bit)
   # build-armv7:

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,9 +40,10 @@ RUN set -eux; \
     awk 'BEGIN{done=0} {print} /^prepare[[:space:]]*\(\)[[:space:]]*\{$/ && !done { \
       print "    default_prepare"; \
       print "    sed -i '\''s/#define USER_PASS_LEN 128/#define USER_PASS_LEN (1 << 17)/'\'' src/openvpn/misc.h"; \
+      print "    sed -i '\''/define(\\[PRODUCT_VERSION_PATCH\\]/ s/])/-longpass1])/'\'' version.m4"; \
       done=1 }' APKBUILD > APKBUILD.tmp && mv APKBUILD.tmp APKBUILD; \
   else \
-    printf '\nprepare() {\n    default_prepare\n    sed -i '\''s/#define USER_PASS_LEN 128/#define USER_PASS_LEN (1 << 17)/'\'' src/openvpn/misc.h\n}\n' >> APKBUILD; \
+    printf '\nprepare() {\n    default_prepare\n    sed -i '\''s/#define USER_PASS_LEN 128/#define USER_PASS_LEN (1 << 17)/'\'' src/openvpn/misc.h\n    sed -i '\''/define(\\[PRODUCT_VERSION_PATCH\\]/ s/])/-longpass1])/'\'' version.m4\n}\n' >> APKBUILD; \
   fi
 
 # keygen, trust pubkey, install makedepends into the current root, then build with fakeroot (no chroot)

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -39,6 +39,10 @@ RUN set -eux; \
     quilt new long-passlen.patch && \
     quilt add src/openvpn/misc.h && \
     sed -i 's/#define USER_PASS_LEN 128/#define USER_PASS_LEN (1 << 17)/' src/openvpn/misc.h && \
+    quilt refresh && \
+    quilt new version-suffix.patch && \
+    quilt add version.m4 && \
+    sed -i '/define(\[PRODUCT_VERSION_PATCH\]/ s/])/-longpass1])/' version.m4 && \
     quilt refresh
 
 # set maintainer info for dch


### PR DESCRIPTION
## Summary
- append `-longpass1` to OpenVPN build via Dockerfiles
- verify OpenVPN `--version` output in build workflows

## Testing
- `docker build -f Dockerfile.debian -t test-openvpn-debian .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a770cd7ff48332b7970a776d84b207